### PR TITLE
Support multiple languages for README, support Explicit Support Tag

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: drauger-welcome
-Version: 5.1.1
+Version: 5.1.3
 Maintainer: Thomas Castleman <contact@draugeros.org>
 Section: misc
 Homepage: https://github.com/drauger-os-development/drauger-welcome

--- a/usr/bin/drauger-welcome
+++ b/usr/bin/drauger-welcome
@@ -27,7 +27,7 @@ import sys
 import os
 import subprocess as subproc
 import drauger_welcome
-VERSION = "5.1.1"
+VERSION = "5.1.3"
 HELP = """
 drauger-welcome, Version %s
 \t-b, --boot-time         Run boot time checks.

--- a/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
+++ b/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
@@ -22,6 +22,7 @@
 #  MA 02110-1301, USA.
 #
 #
+import urllib.request
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -377,8 +378,17 @@ Drauger OS %s
 
     def show_readme(self, widget):
         version = subprocess.check_output(["lsb_release", "-rs"]).decode()[:-1]
-        subprocess.Popen(["xdg-open",
-                          f"https://download.draugeros.org/docs/{version}/README.pdf"])
+        url = f"https://download.draugeros.org/docs/{version}/README-{LANG}.pdf"
+        headers = {"User-Agent": "drauger-welcome/1.0"}
+        request = urllib.request.Request(url, headers=headers)
+
+        try:
+            response = urllib.request.urlopen(request)
+            response.close()
+            subprocess.Popen(["xdg-open", url])
+        except:
+            subprocess.Popen(["xdg-open",
+                              f"https://download.draugeros.org/docs/{version}/README.pdf"])
 
     def start_up_toggle(self, widget):
         global show_at_start_up

--- a/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
+++ b/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
@@ -390,7 +390,7 @@ Drauger OS %s
             subprocess.Popen(["xdg-open", url])
         except HTTPError:
             subprocess.Popen(["xdg-open",
-                              "https://download.draugeros.org/docs/"\
+                              "https://download.draugeros.org/docs/"
                               f"{version}/README.pdf"])
 
     def start_up_toggle(self, widget):

--- a/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
+++ b/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
@@ -390,8 +390,8 @@ Drauger OS %s
             subprocess.Popen(["xdg-open", url])
         except HTTPError:
             subprocess.Popen(["xdg-open",
-                              f"https://download.draugeros.org/docs/{version}/"\
-                              "README.pdf"])
+                              "https://download.draugeros.org/docs/"\
+                              f"{version}/README.pdf"])
 
     def start_up_toggle(self, widget):
         global show_at_start_up

--- a/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
+++ b/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
@@ -62,7 +62,7 @@ try:
     except FileNotFoundError:
         with open("/etc/drauger-locales/%s/drauger-welcome.json" % (LANG),
                   "r") as FILE:
-            contents = json.read(FILE)
+            contents = json.load(FILE)
         if "data" in contents.keys():
             contents = contents["data"]
     for each in contents:
@@ -154,6 +154,8 @@ try:
             lang_sup3 = each[1]
         elif (each[0] == "lang_sup4"):
             lang_sup4 = each[1]
+        elif (each[0] == "Open"):
+            Open = each[1]
 
 except FileNotFoundError:
     message_show_remove = "\n\tThank you again for using Drauger OS. Would you like to uninstall drauger-welcome?\t\n"

--- a/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
+++ b/usr/lib/python3/dist-packages/drauger_welcome/main_ui.py
@@ -23,6 +23,7 @@
 #
 #
 import urllib.request
+from urllib.error import HTTPError
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -378,7 +379,8 @@ Drauger OS %s
 
     def show_readme(self, widget):
         version = subprocess.check_output(["lsb_release", "-rs"]).decode()[:-1]
-        url = f"https://download.draugeros.org/docs/{version}/README-{LANG}.pdf"
+        url = f"https://download.draugeros.org/docs/{version}/"\
+              f"README-{LANG}.pdf"
         headers = {"User-Agent": "drauger-welcome/1.0"}
         request = urllib.request.Request(url, headers=headers)
 
@@ -386,9 +388,10 @@ Drauger OS %s
             response = urllib.request.urlopen(request)
             response.close()
             subprocess.Popen(["xdg-open", url])
-        except:
+        except HTTPError:
             subprocess.Popen(["xdg-open",
-                              f"https://download.draugeros.org/docs/{version}/README.pdf"])
+                              f"https://download.draugeros.org/docs/{version}/"\
+                              "README.pdf"])
 
     def start_up_toggle(self, widget):
         global show_at_start_up

--- a/usr/share/drauger-welcome/tut.py
+++ b/usr/share/drauger-welcome/tut.py
@@ -97,6 +97,8 @@ def has_support(url):
         support_policy = support_policy[release]
     except (KeyError, IndexError):
         return 0
+    if support_policy == "AAU":
+        return 0
     if support_policy == "AEL":
         return 1
     if support_policy == "EWR":


### PR DESCRIPTION
 - Add support for attempting to open a README file that matches the current system locale
   - If no matching README is found, default to the OG README
 - Add support for the new Explicit Support Tag
   - EOL.txt now has an explicit support tag. This has been created to automate the build and deployment process more.